### PR TITLE
Enable thread-local destructors on horizon

### DIFF
--- a/library/std/src/sys/unix/thread_local_dtor.rs
+++ b/library/std/src/sys/unix/thread_local_dtor.rs
@@ -93,7 +93,7 @@ pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     }
 }
 
-#[cfg(target_os = "vxworks")]
+#[cfg(any(target_os = "vxworks", target_os = "horizon"))]
 pub unsafe fn register_dtor(t: *mut u8, dtor: unsafe extern "C" fn(*mut u8)) {
     use crate::sys_common::thread_local_dtor::register_dtor_fallback;
     register_dtor_fallback(t, dtor);


### PR DESCRIPTION
@AzureMarker @Meziu

Broken out from https://github.com/Meziu/rust-horizon/pull/16

Always use fallback thread_local destructor.