### PR TITLE
Minor cleanup to comments + cfgs

### DIFF
--- a/library/std/src/os/horizon/fs.rs
+++ b/library/std/src/os/horizon/fs.rs
@@ -3,6 +3,7 @@
 use crate::fs::Metadata;
 use crate::sys_common::AsInner;
 
+/// OS-specific extensions to [`fs::Metadata`].
 ///
 /// [`fs::Metadata`]: crate::fs::Metadata
 #[stable(feature = "metadata_ext", since = "1.1.0")]

--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -248,7 +248,7 @@ mod imp {
     }
 }
 
-#[cfg(any(target_os = "espidf"))]
+#[cfg(target_os = "espidf")]
 mod imp {
     use super::Args;
 

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -206,7 +206,7 @@ impl FileDesc {
         }
     }
     #[cfg(any(
-        all(target_env = "newlib", not(target_os = "espidf"), not(target_os = "horizon")),
+        all(target_env = "newlib", not(any(target_os = "espidf", target_os = "horizon"))),
         target_os = "solaris",
         target_os = "illumos",
         target_os = "emscripten",
@@ -230,7 +230,7 @@ impl FileDesc {
     #[cfg(any(target_os = "espidf", target_os = "horizon"))]
     pub fn set_cloexec(&self) -> io::Result<()> {
         // FD_CLOEXEC is not supported in ESP-IDF and Horizon OS but there's no need to,
-        // because both do not support spawning processes either.
+        // because neither supports spawning processes either.
         Ok(())
     }
 

--- a/library/std/src/sys/unix/fd.rs
+++ b/library/std/src/sys/unix/fd.rs
@@ -230,7 +230,7 @@ impl FileDesc {
     #[cfg(any(target_os = "espidf", target_os = "horizon"))]
     pub fn set_cloexec(&self) -> io::Result<()> {
         // FD_CLOEXEC is not supported in ESP-IDF and Horizon OS but there's no need to,
-        // because neither supports spawning processes either.
+        // because neither supports spawning processes.
         Ok(())
     }
 

--- a/library/std/src/sys/unix/process/process_unix.rs
+++ b/library/std/src/sys/unix/process/process_unix.rs
@@ -288,7 +288,7 @@ impl Command {
             cvt_r(|| libc::dup2(fd, libc::STDERR_FILENO))?;
         }
 
-        #[cfg(not(any(target_os = "l4re", target_os = "horizon")))]
+        #[cfg(not(target_os = "l4re"))]
         {
             if let Some(_g) = self.get_groups() {
                 //FIXME: Redox kernel does not support setgroups yet
@@ -573,7 +573,6 @@ impl Process {
         self.pid as u32
     }
 
-    #[cfg(not(target_os = "horizon"))]
     pub fn kill(&mut self) -> io::Result<()> {
         // If we've already waited on this process then the pid can be recycled
         // and used for another process, and we probably shouldn't be killing
@@ -588,12 +587,6 @@ impl Process {
         }
     }
 
-    #[cfg(target_os = "horizon")]
-    pub fn kill(&mut self) -> io::Result<()> {
-        Err(Error::new(ErrorKind::Other, "kill not implemented on this os"))
-    }
-
-    #[cfg(not(target_os = "horizon"))]
     pub fn wait(&mut self) -> io::Result<ExitStatus> {
         use crate::sys::cvt_r;
         if let Some(status) = self.status {
@@ -605,12 +598,6 @@ impl Process {
         Ok(ExitStatus::new(status))
     }
 
-    #[cfg(target_os = "horizon")]
-    pub fn wait(&mut self) -> io::Result<ExitStatus> {
-        Err(Error::new(ErrorKind::Other, "wait not implemented on this os"))
-    }
-
-    #[cfg(not(target_os = "horizon"))]
     pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
         if let Some(status) = self.status {
             return Ok(Some(status));
@@ -623,11 +610,6 @@ impl Process {
             self.status = Some(ExitStatus::new(status));
             Ok(Some(ExitStatus::new(status)))
         }
-    }
-
-    #[cfg(target_os = "horizon")]
-    pub fn try_wait(&mut self) -> io::Result<Option<ExitStatus>> {
-        Err(Error::new(ErrorKind::Other, "try_wait not implemented on this os"))
     }
 }
 
@@ -697,14 +679,6 @@ impl From<c_int> for ExitStatus {
     }
 }
 
-#[cfg(target_os = "horizon")]
-impl fmt::Display for ExitStatus {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "formatting ExitStatus can not be implemented")
-    }
-}
-
-#[cfg(not(target_os = "horizon"))]
 impl fmt::Display for ExitStatus {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(code) = self.code() {

--- a/library/std/src/sys/unix/rand.rs
+++ b/library/std/src/sys/unix/rand.rs
@@ -49,12 +49,22 @@ mod imp {
         unsafe { libc::getrandom(buf.as_mut_ptr().cast(), buf.len(), 0) }
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "espidf", target_os = "horizon")))]
+    #[cfg(not(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "espidf",
+        target_os = "horizon"
+    )))]
     fn getrandom_fill_bytes(_buf: &mut [u8]) -> bool {
         false
     }
 
-    #[cfg(any(target_os = "linux", target_os = "android", target_os = "espidf", target_os = "horizon"))]
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "espidf",
+        target_os = "horizon"
+    ))]
     fn getrandom_fill_bytes(v: &mut [u8]) -> bool {
         use crate::sync::atomic::{AtomicBool, Ordering};
         use crate::sys::os::errno;


### PR DESCRIPTION
Changes in this PR as per #3 discussion:

* Minor cleanup of `cfg` that we touched
* Remove all references to Horizon in `process_unix.rs`. We already `cfg` it out in https://github.com/AzureMarker/rust-horizon/blob/feature/horizon-std/library/std/src/sys/unix/process/mod.rs#L17 so there should be no need to update defs in `process_unix`, as far as I can tell?
* Add some missing doc comments / reword things slightly
* `x.py fmt` to make sure we are using consistent formatting