### PR TITLE
EXE_SUFFIX value fix

### DIFF
--- a/library/std/src/sys/unix/env.rs
+++ b/library/std/src/sys/unix/env.rs
@@ -126,7 +126,7 @@ pub mod os {
     pub const DLL_PREFIX: &str = "lib";
     pub const DLL_SUFFIX: &str = ".so";
     pub const DLL_EXTENSION: &str = "so";
-    pub const EXE_SUFFIX: &str = "";
+    pub const EXE_SUFFIX: &str = ".elf";
     pub const EXE_EXTENSION: &str = "elf";
 }
 


### PR DESCRIPTION
As @ian-h-chamberlain documented by asking on the Zulip group, the `EXE_SUFFIX` and `EXE_EXTENSION` should be the same (for sake of historical compatibility) with the only difference of one dot.